### PR TITLE
can now pip install dm-reverb-macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,172 @@ python_bin_path.sh
 bazel-*
 .ipynb_checkpoints
 .reverb.bazelrc
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Reverb
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dm-reverb)
-[![PyPI version](https://badge.fury.io/py/dm-reverb.svg)](https://badge.fury.io/py/dm-reverb)
+# Reverb (MacOS)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dm-reverb-macos)
+[![PyPI version](https://badge.fury.io/py/dm-reverb-macos.svg)](https://badge.fury.io/py/dm-reverb-macos)
 
 Reverb is an efficient and easy-to-use data storage and transport system
 designed for machine learning research. Reverb is primarily used as an
@@ -25,7 +25,7 @@ LIFO, and priority queues.
 Please keep in mind that Reverb is not hardened for production use, and while we
 do our best to keep things in working order, things may break or segfault.
 
-> :warning: Reverb currently only supports Linux based OSes.
+> :warning: This Reverb currently only supports MacOS.
 
 The recommended way to install Reverb is with `pip`. We also provide instructions
 to build from source using the same docker images we use for releases.
@@ -34,21 +34,21 @@ TensorFlow can be installed separately or as part of the `pip` install.
 Installing TensorFlow as part of the install ensures compatibility.
 
 ```shell
-$ pip install dm-reverb[tensorflow]
+$ pip install dm-reverb-macos[tensorflow]
 
 # Without Tensorflow install and version dependency check.
-$ pip install dm-reverb
+$ pip install dm-reverb-macos
 ```
 
 ### Nightly builds
 
-[![PyPI version](https://badge.fury.io/py/dm-reverb-nightly.svg)](https://badge.fury.io/py/dm-reverb-nightly)
+[![PyPI version](https://badge.fury.io/py/dm-reverb-macos-nightly.svg)](https://badge.fury.io/py/dm-reverb-macos-nightly)
 
 ```shell
-$ pip install dm-reverb-nightly[tensorflow]
+$ pip install dm-reverb-macos-nightly[tensorflow]
 
 # Without Tensorflow install and version dependency check.
-$ pip install dm-reverb-nightly
+$ pip install dm-reverb-macos-nightly
 
 ```
 
@@ -375,7 +375,7 @@ for details on the implementation of checkpointing in Reverb.
 
 ## Starting Reverb using `reverb_server` (beta)
 
-Installing `dm-reverb` using `pip` will install a `reverb_server` script, which
+Installing `dm-reverb-macos` using `pip` will install a `reverb_server` script, which
 accepts its config as a textproto. For example:
 
 ```bash

--- a/reverb/pip_package/setup.py
+++ b/reverb/pip_package/setup.py
@@ -25,7 +25,6 @@ from setuptools import setup
 from setuptools.command.install import install as InstallCommandBase
 from setuptools.dist import Distribution
 
-import reverb_version
 
 # Defaults if doing a release build.
 TENSORFLOW_VERSION = 'tensorflow~=2.12.0'
@@ -71,11 +70,11 @@ class SetupToolsHelper(object):
   def _get_version(self):
     """Returns the version and project name to associate with the build."""
     if self.release:
-      project_name = 'dm-reverb'
-      version = reverb_version.__rel_version__
+      project_name = 'dm-reverb-macos'
+      version = '0.11.0.dev'
     else:
-      project_name = 'dm-reverb-nightly'
-      version = reverb_version.__dev_version__
+      project_name = 'dm-reverb-macos-nightly'
+      version = '0.11.0'
       version += datetime.datetime.now().strftime('%Y%m%d')
 
     return version, project_name
@@ -120,7 +119,7 @@ class SetupToolsHelper(object):
         long_description_content_type='text/markdown',
         author='DeepMind',
         author_email='DeepMind <no-reply@google.com>',
-        url='https://github.com/deepmind/reverb',
+        url='https://github.com/engichang1467/reverb',
         license='Apache 2.0',
         packages=find_packages(),
         headers=list(find_files('*.proto', 'reverb')),


### PR DESCRIPTION
Now the package can now be installed through pypl

```
pip install dm-reverb-macos
```

## Update
- update gitignore
- update the naming